### PR TITLE
Remove deps caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,20 +9,10 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
-            - v1-dependencies-
-
       - run:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
-
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
 
       - run:
           name: run tests


### PR DESCRIPTION
I failed to realise that you don't even want to cache dependencies for libraries in CI in the first place, for the same reason gems don't include a `Gemfile.lock` in the repo. So sorry for nagging about it I guess 🤷‍♂