### PR TITLE
Fix things

### DIFF
--- a/lib/ostiary/controller_helper.rb
+++ b/lib/ostiary/controller_helper.rb
@@ -37,12 +37,12 @@ module Ostiary
         raise ArgumentError, "Use either only or except"       if except && only
         raise ArgumentError, "Use a symbol for method:"        if method && !(method.is_a? Symbol)
 
-        if actions.empty?
-          ostiary.policies << Policy.new(role, method: method&.to_proc)
-        elsif only
+        if only
           ostiary.policies << PolicyLimited.new(role, only, method: method&.to_proc)
         elsif except
           ostiary.policies << PolicyExempted.new(role, except, method: method&.to_proc)
+        else
+          ostiary.policies << Policy.new(role, method: method&.to_proc)
         end
       end
 

--- a/lib/ostiary/ostiary.rb
+++ b/lib/ostiary/ostiary.rb
@@ -8,7 +8,7 @@ module Ostiary
 
     def authorize!(action, &block)
       policies.each do |policy|
-        next if policy.met?(action, block)
+        next if policy.met?(action, &block)
         raise PolicyBroken, policy.error_message(action)
       end
     end

--- a/lib/ostiary/policy.rb
+++ b/lib/ostiary/policy.rb
@@ -12,7 +12,7 @@ module Ostiary
       "#{name}"
     end
 
-    def met?(_action)
+    def met?(_action, &block)
       return yield name unless method
       method.call
     end

--- a/lib/ostiary/policy_exempted.rb
+++ b/lib/ostiary/policy_exempted.rb
@@ -5,7 +5,7 @@ module Ostiary
       "#{name} except for #{actions.to_sentence}"
     end
 
-    def met?(action)
+    def met?(action, &block)
       return true if actions.include?(action)
       super
     end

--- a/lib/ostiary/policy_limited.rb
+++ b/lib/ostiary/policy_limited.rb
@@ -5,7 +5,7 @@ module Ostiary
       "#{name} only for #{actions.to_sentence}"
     end
 
-    def met?(action)
+    def met?(action, &block)
       return true unless actions.include?(action)
       super
     end

--- a/lib/ostiary/version.rb
+++ b/lib/ostiary/version.rb
@@ -1,3 +1,3 @@
 module Ostiary
-  VERSION = "0.11.1"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
I'm not sure I got the history right here, but during the upgrade process to Ruby 3 in Grid, I came across a problem in the currently used `0.8.0` of Ostiary, saying something along the lines of "Attempting to create Proc without a block" for [this line](https://github.com/nedap/ostiary/blob/v0.8.0/lib/ostiary/ostiary.rb#L11).

This line has been refactored away in more recent versions, but to me it seems as if there's a problem with the packaged version of 0.11.1 (it's empty?), and trying to use the corresponding git branch directly, I found some syntax errors that look like the post-0.8.0 refactorings were not quite finished. This PR fixes these errors, and the resulting version seems to be working fine with Ruby 3 in Grid.