### PR TITLE
CircleCI config for publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: push gem release
           command: |
-            gem push
+            gem push ostiary
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,13 +50,9 @@ jobs:
           command: bundle exec rake build
 
       - run:
-          name: release to GitHub
+          name: push gem release
           command: |
-            mkdir -p $HOME/.gem
-            touch $HOME/.gem/credentials
-            chmod 0600 $HOME/.gem/credentials
-            printf -- "---\n:github: Bearer ${GITHUB_TOKEN}\n" > $HOME/.gem/credentials
-            gem push --key github --host https://rubygems.pkg.github.com/nedap pkg/$(ls -Art pkg | tail -n 1)
+            gem push
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.7
+      - image: cimg/ruby:3.1.2
 
     steps:
       - checkout
@@ -29,3 +29,49 @@ jobs:
 
       - store_test_results:
           path: /tmp/test-results
+
+  deploy:
+    docker:
+      - image: cimg/ruby:3.1.2
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: install dependencies
+          command: |
+            gem install bundler:2.2.10
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - run:
+          name: build release
+          command: bundle exec rake build
+
+      - run:
+          name: release to GitHub
+          command: |
+            mkdir -p $HOME/.gem
+            touch $HOME/.gem/credentials
+            chmod 0600 $HOME/.gem/credentials
+            printf -- "---\n:github: Bearer ${GITHUB_TOKEN}\n" > $HOME/.gem/credentials
+            gem push --key github --host https://rubygems.pkg.github.com/nedap pkg/$(ls -Art pkg | tail -n 1)
+
+workflows:
+  version: 2
+  CircleCI:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: /.*/
+
+      - deploy:
+          context:
+            - Github
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+([\w\.]+)?$/ # Support prereleases, see https://guides.rubygems.org/patterns/#prerelease-gems

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,6 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "26:01:13:3d:ac:4b:94:bb:b3:91:50:37:23:0d:6f:ba"
-
       - checkout
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            gem install bundler:2.2.10
+            gem install bundler:2.3.18
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - run:
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            gem install bundler:2.2.10
+            gem install bundler:2.3.18
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - run:
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: push gem release
           command: |
-            gem push ostiary
+            gem push pkg/ostiary*.gem
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
 
     steps:
       - add_ssh_keys:
-        fingerprints:
-          - "f2:22:ee:e6:b5:c9:88:3f:0a:b0:f8:42:0f:90:d1:47"
+          fingerprints:
+            - "f2:22:ee:e6:b5:c9:88:3f:0a:b0:f8:42:0f:90:d1:47"
 
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,10 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - add_ssh_keys:
+        fingerprints:
+          - "f2:22:ee:e6:b5:c9:88:3f:0a:b0:f8:42:0f:90:d1:47"
+
       - checkout
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "f2:22:ee:e6:b5:c9:88:3f:0a:b0:f8:42:0f:90:d1:47"
+            - "26:01:13:3d:ac:4b:94:bb:b3:91:50:37:23:0d:6f:ba"
 
       - checkout
 

--- a/lib/ostiary/version.rb
+++ b/lib/ostiary/version.rb
@@ -1,3 +1,3 @@
 module Ostiary
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end

--- a/lib/ostiary/version.rb
+++ b/lib/ostiary/version.rb
@@ -1,3 +1,3 @@
 module Ostiary
-  VERSION = "0.13.0"
+  VERSION = "0.14.0"
 end

--- a/lib/ostiary/version.rb
+++ b/lib/ostiary/version.rb
@@ -1,3 +1,3 @@
 module Ostiary
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end

--- a/ostiary.gemspec
+++ b/ostiary.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
     servant or guard posted at the entrance of a building. See also gatekeeper."
   TXT
   spec.license = 'MIT'
+  spec.files = Dir.glob("{lib}/**/*") + %w(LICENSE.txt README.md)
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", ">= 2.3.18"

--- a/ostiary.gemspec
+++ b/ostiary.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", ">= 2.2.10"
+  spec.add_development_dependency "bundler", ">= 2.3.18"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'rspec_junit_formatter'


### PR DESCRIPTION
This adds config to automatically publish gem packages when new tags are created, similar to our other repos.

Took me a while to figure out the correct way of configuring access to the repo, thus the multiple version bumps.