### PR TITLE
Fix Ostiary#authorized?

### DIFF
--- a/lib/ostiary/ostiary.rb
+++ b/lib/ostiary/ostiary.rb
@@ -15,7 +15,7 @@ module Ostiary
 
     def authorized?(action, &block)
       policies.all? do |policy|
-        policy.met?(action, block)
+        policy.met?(action, &block)
       end
     end
 


### PR DESCRIPTION
#15 changed the method call of `Policy#met` to explicitly expect a `&block` argument. The `authorized?` method was not updated to the new method signature.